### PR TITLE
ACLOCAL_AMFLAGS conflicts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,3 @@
-ACLOCAL_AMFLAGS = -I./.autocrap
-
 SUBDIRS = src test
 
 pkgconfig_DATA= vsgi-1.0.pc


### PR DESCRIPTION
Hello.

I think VSGI is clever software. :)

Today, I encountered to following issue.

```
$ ./autogen.sh 
libtoolize: AC_CONFIG_MACRO_DIR([.autocrap]) conflicts with ACLOCAL_AMFLAGS=-I ./.autocrap.
autoreconf: libtoolize failed with exit status: 1
./autogen.sh: 9: ./autogen.sh: ./configure: not found

$ uname -a
Linux ubuntu 3.13.0-33-generic #58-Ubuntu SMP Tue Jul 29 16:45:05 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux

$ valac --version
Vala 0.22.1
```

It seems duplicated definition in Makefile.am:1

**If this issue contains some misunderstands, please reject this pull-request.**

How do you think? 

Best regards.
